### PR TITLE
Fix popupwindow function

### DIFF
--- a/class.shortcode.php
+++ b/class.shortcode.php
@@ -145,6 +145,7 @@ class dtbaker_Shortcode_Banner {
 				    // this is called from our tinymce plugin, also can call from our "edit" function above
 				    // wp.mce.boutique_banner.popupwindow(tinyMCE.activeEditor, "bird");
 				    popupwindow: function(editor, values, onsubmit_callback){
+				    	values = values || [];
 					    if(typeof onsubmit_callback != 'function'){
 						    onsubmit_callback = function( e ) {
 		                        // Insert content when the window form is submitted (this also replaces during edit, handy!)


### PR DESCRIPTION
Set values to avoid undefined error breaking custom tinymce button, which in turn stops it from opening the popup window.